### PR TITLE
Add typecasts to remove -fpermissive in client compilation line

### DIFF
--- a/buffer.h
+++ b/buffer.h
@@ -140,7 +140,7 @@ static inline void *buffer_put_data(struct buffer *b, const void *data,   size_t
 
 static inline int buffer_put_u8(struct buffer *b, uint8_t val)
 {
-    uint8_t *p = buffer_put(b, 1);
+    uint8_t *p = (uint8_t*) buffer_put(b, 1);
 
     if (likely(p)) {
         *p = val;
@@ -152,7 +152,7 @@ static inline int buffer_put_u8(struct buffer *b, uint8_t val)
 
 static inline int buffer_put_u16(struct buffer *b, uint16_t val)
 {
-    uint16_t *p = buffer_put(b, 2);
+    uint16_t *p = (uint16_t*) buffer_put(b, 2);
 
     if (likely(p)) {
         *p = val;
@@ -174,7 +174,7 @@ static inline int buffer_put_u16le(struct buffer *b, uint16_t val)
 
 static inline int buffer_put_u32(struct buffer *b, uint32_t val)
 {
-    uint32_t *p = buffer_put(b, 4);
+    uint32_t *p = (uint32_t*) buffer_put(b, 4);
 
     if (likely(p)) {
         *p = val;
@@ -196,7 +196,7 @@ static inline int buffer_put_u32le(struct buffer *b, uint32_t val)
 
 static inline int buffer_put_u64(struct buffer *b, uint64_t val)
 {
-    uint64_t *p = buffer_put(b, 8);
+    uint64_t *p = (uint64_t*) buffer_put(b, 8);
 
     if (likely(p)) {
         *p = val;
@@ -219,7 +219,7 @@ static inline int buffer_put_u64le(struct buffer *b, uint64_t val)
 static inline int buffer_put_string(struct buffer *b, const char *s)
 {
     size_t len = strlen(s);
-    char *p = buffer_put(b, len);
+    char *p = (char*) buffer_put(b, len);
 
     if (likely(p)) {
         memcpy(p, s, len);


### PR DESCRIPTION
Using `libuwsc` requires `-fpermissive` c++ flag due to these implicit typecasts.
Just adding those explicitly to remove errors.

There is no `pragma ignore '-fpermissive'` after gcc 4.7.
https://stackoverflow.com/questions/10932479/in-gcc-how-to-mute-the-fpermissive-warning