### PR TITLE
Define data_size as size_t in buffer_resize

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -38,7 +38,7 @@ int buffer_resize(struct buffer *b, size_t size)
 {
     uint8_t *head;
     size_t new_size = getpagesize();
-    int data_len = buffer_length(b);
+    size_t data_len = buffer_length(b);
 
     while (new_size < size)
         new_size <<= 1u;


### PR DESCRIPTION
Avoids segmentation faults when buffer length grows beyond 2GB.

Buffer length returns a size_t (unsigned) which is than onverted to a signed integer (that becomes negative when overflowed).

A segmentation fault occurs if the buffer length grows beyond 2GB, such that data_size becomes negative, from which buffer->tail is calculated. Access to the latter causes a segmentation fault.

Simple program to reproduce the issue:

```c

int main() {
        int i = 0x7fffffff;
        struct buffer buf = {};

        printf("Size of int is %zu\n", sizeof(int));
        printf("Size of page is %zu\n", getpagesize());
        printf("Integer %04x is %d\n", i, i);
        printf("Integer %04x is %d\n", i+1, i+1);

        buffer_init(&buf, i);

        printf("Buf size is %zu head %p, data %p, tail %p, end %p\n",
                        buffer_size(&buf), buf.head, buf.data, buf.tail, buf.end);

        buf.tail = buf.end;
        buffer_put_u8(&buf, '1');

        printf("Buf size is %zu head %p, data %p, tail %p, end %p\n",
                        buffer_size(&buf), buf.head, buf.data, buf.tail, buf.end);

        return 0;
}
```
$ gdb ./a.out
...
Size of int is 4
Integer 7fffffff is 2147483647
Integer 80000000 is -2147483648
Buf size is 2147483648 head 0x7fff77de6010, data 0x7fff77de6010, tail 0x7fff77de6010, end 0x7ffff7de6010

Program received signal SIGSEGV, Segmentation fault. 0x0000555555555276 in buffer_put_u8 (b=0x7fffffffe350, val=49 '1') at /ub/include/uwsc/buffer.h:146
146             *p = val;
(gdb) bt
(gdb) print p
$1 = (uint8_t *) 0x7ffdf7de5010 <error: Cannot access memory at address 0x7ffdf7de5010>
(gdb) print b->head
$2 = (uint8_t *) 0x7ffe77de5010 ""
(gdb) print b->data
$3 = (uint8_t *) 0x7ffe77de5010 ""
(gdb) print b->tail
$4 = (uint8_t *) 0x7ffdf7de5011 <error: Cannot access memory at address 0x7ffdf7de5011>
(gdb) print b->end
$5 = (uint8_t *) 0x7fff77de5010 ""
(gdb) print 0x7ffdf7de5011 - 0x7ffe77de5010
$6 = -2147483647
(gdb) quit